### PR TITLE
회원가입 API 추가

### DIFF
--- a/src/common/errors/custom.ts
+++ b/src/common/errors/custom.ts
@@ -11,3 +11,6 @@ export abstract class CustomError extends Error {
         Object.setPrototypeOf(this, CustomError.prototype);
     }
 }
+
+
+export const ErrAlreadyExist = "already exist"

--- a/src/configs/database.ts
+++ b/src/configs/database.ts
@@ -1,7 +1,6 @@
 import { Sequelize, Dialect } from "sequelize";
 import { initUser } from "@models/user";
 import { initPost } from "@models/post";
-import { logger } from "./logger";
 
 const DBConfigs = {
     username: process.env.DB_USERNAME || "postgres",

--- a/src/controllers/anonymous/anonymous.controller.ts
+++ b/src/controllers/anonymous/anonymous.controller.ts
@@ -5,6 +5,7 @@ import redis from "@configs/redis";
 import AnonymousService from "@services/anonymous/anonymous.service";
 import InternalError from "@errors/internal_server";
 import BadRequestError from "@errors/bad_request";
+import { CustomError, ErrAlreadyExist } from "@errors/custom";
 
 export default class AnonymousController {
     private anonymouseService: AnonymousService;
@@ -16,10 +17,17 @@ export default class AnonymousController {
     signup = async (req: Request, res: Response) => {
         const body: dto.SignupReqDTO = req.body;
         try {
-            const result = this.anonymouseService.signup(body);
+            const u = await this.anonymouseService.signup(body);
 
-            res.send({ message: "aaa" });
+            if (!u) {
+                throw new InternalError({ error: new Error("cant find user but created") });
+            }
+
+            res.send({ message: "success created user", data: u.dataValues });
         } catch (err: any) {
+            if (err.message === ErrAlreadyExist) {
+                throw new BadRequestError({ error: err });
+            }
             throw new InternalError({ error: err });
         }
     };

--- a/src/controllers/anonymous/anonymous.controller.ts
+++ b/src/controllers/anonymous/anonymous.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 
 import * as dto from "@controllers/anonymous/dto/anonymous.dto";
 import redis from "@configs/redis";
-import AnonymousService from "@services/anonymous.service";
+import AnonymousService from "@services/anonymous/anonymous.service";
 import InternalError from "@errors/internal_server";
 import BadRequestError from "@errors/bad_request";
 
@@ -16,7 +16,8 @@ export default class AnonymousController {
     signup = async (req: Request, res: Response) => {
         const body: dto.SignupReqDTO = req.body;
         try {
-            await this.anonymouseService.test();
+            const result = this.anonymouseService.signup(body);
+
             res.send({ message: "aaa" });
         } catch (err: any) {
             throw new InternalError({ error: err });

--- a/src/controllers/anonymous/dto/anonymous.dto.ts
+++ b/src/controllers/anonymous/dto/anonymous.dto.ts
@@ -17,6 +17,7 @@ export class SignupReqDTO {
     @IsNotEmpty()
     email!: string;
 }
+
 export class LoginReqDTO {
     @IsString()
     @MinLength(3, { message: "ID is too short" })

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -3,6 +3,8 @@ import { Model, DataTypes, Sequelize } from "sequelize";
 
 class User extends Model {
     public id!: number;
+    public userID!: string;
+    public password!: string;
     public username!: string;
     public email!: string;
 }
@@ -15,12 +17,7 @@ export const initUser = (sequelize: Sequelize) => {
                 autoIncrement: true,
                 primaryKey: true,
             },
-            username: {
-                type: DataTypes.STRING,
-                allowNull: false,
-                unique: true,
-            },
-            user_id: {
+            userID: {
                 type: DataTypes.STRING,
                 allowNull: false,
                 unique: true,
@@ -28,6 +25,11 @@ export const initUser = (sequelize: Sequelize) => {
             password: {
                 type: DataTypes.STRING,
                 allowNull: false,
+            },
+            username: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                unique: true,
             },
             email: {
                 type: DataTypes.STRING,

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,12 +1,12 @@
 // models/User.ts
-import { Model, DataTypes, Sequelize } from "sequelize";
+import { Model, DataTypes, Sequelize, InferCreationAttributes, InferAttributes, CreationOptional } from "sequelize";
 
-class User extends Model {
-    public id!: number;
-    public userID!: string;
-    public password!: string;
-    public username!: string;
-    public email!: string;
+class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+    declare id: CreationOptional<number>;
+    declare userID: string;
+    declare password: string;
+    declare username: string;
+    declare email: string;
 }
 
 export const initUser = (sequelize: Sequelize) => {

--- a/src/repository/anonymous.repo.ts
+++ b/src/repository/anonymous.repo.ts
@@ -1,19 +1,36 @@
 import User from "@models/user";
-import { Sequelize } from "sequelize";
 
 export default class AnonymousRepo {
     constructor() {}
 
-    public async createUser(username: string, email: string, password: string): Promise<User> {
+    findUserByUserID = async (userID: string) => {
+        return await User.findOne({
+            where: {
+                userID: userID,
+            },
+        });
+    };
+    findUserByEmail = async (email: string) => {
+        return await User.findOne({
+            where: {
+                email: email,
+            },
+        });
+    };
+
+    createUser = async (user: User) => {
         try {
-            const user = await User.create({
-                username,
-                email,
-                password,
+            // TODO: 왜 model로 삽입 시 안되는지 추후에 해결해보기
+            // const u = await User.create(user);
+            const u = await User.create({
+                userID: user.userID,
+                username: user.username,
+                password: user.password,
+                email: user.email,
             });
-            return user;
-        } catch (error) {
-            throw error;
+            return u;
+        } catch (err: any) {
+            throw err;
         }
-    }
+    };
 }

--- a/src/services/anonymous/anonymous.conv.ts
+++ b/src/services/anonymous/anonymous.conv.ts
@@ -2,10 +2,10 @@ import * as dto from "@controllers/anonymous/dto/anonymous.dto";
 import User from "@models/user";
 
 export const convSignupToUser = (userDTO: dto.SignupReqDTO): User => {
-    const user = new User();
-    user.userID = userDTO.userID;
-    user.password = userDTO.password;
-    user.username = userDTO.username;
-    user.email = userDTO.email;
-    return user;
+    return new User({
+        userID: userDTO.userID,
+        password: userDTO.password,
+        username: userDTO.username,
+        email: userDTO.email,
+    });
 };

--- a/src/services/anonymous/anonymous.conv.ts
+++ b/src/services/anonymous/anonymous.conv.ts
@@ -1,0 +1,11 @@
+import * as dto from "@controllers/anonymous/dto/anonymous.dto";
+import User from "@models/user";
+
+export const convSignupToUser = (userDTO: dto.SignupReqDTO): User => {
+    const user = new User();
+    user.userID = userDTO.userID;
+    user.password = userDTO.password;
+    user.username = userDTO.username;
+    user.email = userDTO.email;
+    return user;
+};

--- a/src/services/anonymous/anonymous.service.ts
+++ b/src/services/anonymous/anonymous.service.ts
@@ -1,6 +1,7 @@
-import { SignupReqDTO } from "@controllers/anonymous/dto/anonymous.dto";
+
 import AnonymousRepo from "@repo/anonymous.repo";
 import { issueAccessToken, issueRefreshToken } from "@utils/jwt";
+import * as dto from "@controllers/anonymous/dto/anonymous.dto";
 
 interface AccessTokenPayload {
     // 알아서 추가할 것
@@ -15,10 +16,10 @@ export default class AnonymousService {
         this.anonymousRepo = new AnonymousRepo();
     }
 
-    test = async () => {
-        // unique한지 확인 과정
-        return true;
-    };
+    signup = async (userDTO: dto.SignupReqDTO) => {
+        
+    }
+
 
     login = async (userID: string, pw: string) => {
         //  user login 로직 - DB에 접근하여 id pw 대조


### PR DESCRIPTION
* res.send할 때 들어가는 `message`, `data`와 같은 key를 추후 정리하는 pr 생성
* sequelize에서 Model인 User.create(user) 에서 왜 user의 value에 대해 인식하지 못하는지 확인
  - 임시로 직접 user  안에 값들을 parsing하여 직접 넣어주는 방식으로 해결