### PR TITLE
Update user api 구현

### DIFF
--- a/src/controllers/anonymous/anonymous.controller.ts
+++ b/src/controllers/anonymous/anonymous.controller.ts
@@ -25,6 +25,8 @@ export default class AnonymousController {
             if (!u) {
                 throw new InternalError({ error: new Error("cant find user but created") });
             }
+            // delete user's password
+            u.password = ""
 
             res.send({ message: "success created user", data: u.dataValues });
         } catch (err: any) {

--- a/src/controllers/user/dto/user.dto.ts
+++ b/src/controllers/user/dto/user.dto.ts
@@ -1,0 +1,15 @@
+import { IsEmail, IsOptional, IsString } from "@utils/validation";
+
+export class UpdateUserReqDTO {
+    @IsString()
+    @IsOptional()
+    password!: string;
+    
+    @IsString()
+    @IsOptional()
+    username!: string;
+    
+    @IsEmail()
+    @IsOptional()
+    email!: string;
+}

--- a/src/controllers/user/dto/user.dto.ts
+++ b/src/controllers/user/dto/user.dto.ts
@@ -4,12 +4,12 @@ export class UpdateUserReqDTO {
     @IsString()
     @IsOptional()
     password!: string;
-    
+
     @IsString()
     @IsOptional()
     username!: string;
-    
-    @IsEmail()
+
     @IsOptional()
-    email!: string;
+    @IsEmail()
+    email!: string; // IsOptional + IsEmail - 애초에 email key가 오면 안됨.
 }

--- a/src/controllers/user/user.controller.ts
+++ b/src/controllers/user/user.controller.ts
@@ -1,10 +1,14 @@
 import { Request, Response } from "express";
 
+// common
+import { ErrNotFound } from "@errors/custom";
+import BadRequestError from "@errors/bad_request";
+import InternalError from "@errors/internal_server";
 import RedisClient, { Redis } from "@configs/redis";
+
+// server
+import * as dto from "@controllers/user/dto/user.dto";
 import UserService from "@services/user/user.service";
-import { ErrNotFound } from "@src/common/errors/custom";
-import BadRequestError from "@src/common/errors/bad_request";
-import InternalError from "@src/common/errors/internal_server";
 import User from "@models/user";
 
 export default class UserController {
@@ -42,4 +46,19 @@ export default class UserController {
             throw new InternalError({ error: err });
         }
     };
+    updateUser = async (req: Request, res: Response) => {
+        const id = req.params.id;
+        const body: dto.UpdateUserReqDTO = req.body;
+        try {
+            const u = await this.userService.updateUser(id, body);
+            // delete user's password
+            u.password = ""
+            res.send({ message: `success get user (id : ${id})`, data: u.dataValues });
+        } catch (err: any) {
+            if (err.message === ErrNotFound) {
+                throw new BadRequestError({ code: 404, error: err });
+            }
+            throw new InternalError({ error: err });
+        }
+    }
 }

--- a/src/controllers/user/user.controller.ts
+++ b/src/controllers/user/user.controller.ts
@@ -24,8 +24,10 @@ export default class UserController {
     getUser = async (req: Request, res: Response) => {
         const id = req.params.id;
         try {
-            const user: User = await this.userService.getUser(id);
-            res.send({ message: `success get user (id : ${id})`, data: user.dataValues });
+            const u: User = await this.userService.getUser(id);
+            // delete user's password
+            u.password = ""
+            res.send({ message: `success get user (id : ${id})`, data: u.dataValues });
         } catch (err: any) {
             if (err.message === ErrNotFound) {
                 throw new BadRequestError({ code: 404, error: err });

--- a/src/repository/user.repo.ts
+++ b/src/repository/user.repo.ts
@@ -1,7 +1,7 @@
 import User from "@models/user";
 
 export default class UserRepo {
-    constructor() {}
+    constructor() { }
 
     findUserByUserID = async (userID: string) => {
         return await User.findOne({
@@ -54,4 +54,28 @@ export default class UserRepo {
             throw err;
         }
     };
+
+    updateUser = async (user: User) => {
+        try {
+            const updatedUser = await User.update(
+                {
+                    username: user.username,
+                    password: user.password,
+                    email: user.email,
+                },
+                {
+                    where: {
+                        id: user.id, // 사용자의 고유 식별자로 업데이트
+                    },
+                }
+            );
+            if (updatedUser[0] === 1) {
+                return user
+            } else {
+                throw new Error("cant update user")
+            }
+        } catch (err) {
+            throw err;
+        }
+    }
 }

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 
 import UserController from "@src/controllers/user/user.controller";
+import * as dto from "@controllers/user/dto/user.dto";
+import { validationMiddleware } from "@src/middlewares/requestValidate";
 class UserRoutes {
     router = Router();
     controller = new UserController();
@@ -12,6 +14,7 @@ class UserRoutes {
     intializeRoutes() {
         this.router.get("/:id", this.controller.getUser);
         this.router.delete("/:id", this.controller.deleteUser);
+        this.router.put("/:id", validationMiddleware(dto.UpdateUserReqDTO), this.controller.updateUser);
     }
 }
 

--- a/src/services/user/user.service.ts
+++ b/src/services/user/user.service.ts
@@ -1,5 +1,10 @@
-import { ErrNotFound } from "@src/common/errors/custom";
-import UserRepo from "@src/repository/user.repo";
+// common
+import { ErrNotFound } from "@errors/custom";
+
+// server
+import * as dto from "@controllers/user/dto/user.dto";
+import UserRepo from "@repo/user.repo";
+import { hashing } from "@src/common/utils/encryption";
 
 export default class UserService {
     private userRepo: UserRepo;
@@ -32,4 +37,25 @@ export default class UserService {
             throw err;
         }
     };
+
+    updateUser = async (targetUserPkID: string, userData: dto.UpdateUserReqDTO) => {
+        try {
+            const user = await this.userRepo.findUserByID(targetUserPkID);
+            if (!user) {
+                throw new Error(ErrNotFound);
+            }
+            if (userData.email) {
+                user.email = userData.email
+            }
+            if (userData.password) {
+                user.password = await hashing(userData.password)
+            }
+            if (userData.username) {
+                user.username = userData.username
+            }
+            return await this.userRepo.updateUser(user);
+        } catch (err) {
+            throw err;
+        }
+    }
 }

--- a/tests/services/user.test.ts
+++ b/tests/services/user.test.ts
@@ -3,10 +3,10 @@ import app from "../setup";
 import User from "@models/user";
 
 interface userBody {
-    userID: string;
-    password: string;
-    username: string;
-    email: string;
+    userID?: string;
+    password?: string;
+    username?: string;
+    email?: string;
 }
 
 let createdUser: User;
@@ -52,7 +52,7 @@ describe("Signup API", () => {
             let response: any = await request(app).post("/api/signup").send(body);
             expect(response.statusCode).toBe(400);
         });
-        test("empty & wrong email", async () => {
+        test("empty & invalid email", async () => {
             body.email = "";
             let response: any = await request(app).post("/api/signup").send(body);
             expect(response.statusCode).toBe(400);
@@ -72,7 +72,7 @@ describe("Get User API", () => {
 
             const result: userBody = response.body.data;
             expect(result.userID).toEqual(createdUser.userID);
-            expect(result.password).toEqual(createdUser.password);
+            expect(result.password).toEqual(""); // password는 FE측으로 유출해선 안된다.
             expect(result.username).toEqual(createdUser.username);
             expect(result.email).toEqual(createdUser.email);
         });
@@ -84,6 +84,56 @@ describe("Get User API", () => {
         });
     });
 });
+
+describe("Update User API", () => {
+    let body: userBody;
+    beforeEach(() => {
+        body = {
+            userID: "", // not used this test
+            username: "",
+            password: "",
+            email: "",
+        };
+    });
+    describe("성공", () => {
+        test(`Put - /api/users/{id}) - username`, async () => {
+            body.username = "changeduser123"
+            delete body.email
+            const response: any = await request(app).put(`/api/users/${createdUser.id}`).send(body);
+            expect(response.statusCode).toBe(200);
+
+            const result: userBody = response.body.data;
+            expect(result.username).toEqual(body.username);
+        });
+        test(`Put - /api/users/{id}) - password`, async () => {
+            body.password = "changeduser313"
+            delete body.email
+            const response: any = await request(app).put(`/api/users/${createdUser.id}`).send(body);
+            expect(response.statusCode).toBe(200);
+        });
+        test(`Put - /api/users/{id}) - email`, async () => {
+            body.email = "changeduser@naver.com"
+            const response: any = await request(app).put(`/api/users/${createdUser.id}`).send(body);
+            expect(response.statusCode).toBe(200);
+
+            const result: userBody = response.body.data;
+            expect(result.email).toEqual(body.email);
+        });
+    });
+    describe("Exception", () => {
+        test("invalid email", async () => {
+            body.email = "invalidemailformat"
+            const response: any = await request(app).put(`/api/users/${createdUser.id}`).send(body);
+            expect(response.statusCode).toBe(400);
+        });
+        test("not found user", async () => {
+            body.email = "changeduser@naver.com"
+            const response: any = await request(app).put(`/api/users/${createdUser.id + 100}`).send(body);
+            expect(response.statusCode).toBe(404);
+        });
+    });
+});
+
 
 describe("Delete User API", () => {
     describe("성공", () => {


### PR DESCRIPTION
예외 상황에 대한 추후 개선이 필요한 부분이 있음.
사용자 update 시 user column 중 변경이 되는 정보만 Client에서 받는 것을 Flow로 API를 구현
현재 Request의 body에 대해서 `class-validator` module을 사용함.  

[ 문제 사항 ] 
* 값이 존재하지 않더라도 validate 되지 않게 하기 위해 `@IsOptional()` decorator를 사용하여 dto 처리해줌.
* 이때 email에서는 해당 decorator가 작동하지 않음. 아래 예시 
```
//  성공 case
{
    "username" : "",
    "email" : "admin@admin.com",
    "password" : "test2131231"
}

// 실패 case
{
    "username" : "",
    "email" : "",
    "password" : "test2131231"
}
// 실패 case
{
    "username" : "",
    "password" : "test2131231"
}
```
* 성공하기 위해서는 email이 변경되지 않을 때에는 Client에서 `email` key를 body에 애초에 포함하여 보내면 안됨.
* 현재는 우선 이렇게 처리를 하고 추후에 수정이 필요할 듯함.
