### PR TITLE
username 중복 API 추가 및 Email당 계정 생성 정책 1개로 변경 반영 및 단위테스트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.552.0",
                 "@aws-sdk/client-ses": "^3.552.0",
+                "@types/ioredis-mock": "^8.2.5",
                 "bcryptjs": "^2.4.3",
                 "body-parser": "^1.20.2",
                 "class-transformer": "^0.5.1",
@@ -24,6 +25,7 @@
                 "express-async-errors": "^3.1.1",
                 "helmet": "^7.1.0",
                 "ioredis": "^5.3.2",
+                "ioredis-mock": "^8.9.0",
                 "jest": "^29.7.0",
                 "jsonwebtoken": "^9.0.2",
                 "morgan": "^1.10.0",
@@ -53,7 +55,6 @@
                 "@types/multer-s3": "^3.0.3",
                 "@types/node": "^20.11.19",
                 "@types/nodemailer": "^6.4.14",
-                "@types/redis-mock": "^0.17.3",
                 "@types/supertest": "^6.0.2",
                 "@types/uuid4": "^2.0.3",
                 "@types/validator": "^13.11.9",
@@ -1536,6 +1537,11 @@
                 "kuler": "^2.0.0"
             }
         },
+        "node_modules/@ioredis/as-callback": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+            "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg=="
+        },
         "node_modules/@ioredis/commands": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
@@ -2843,6 +2849,15 @@
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
             "dev": true
         },
+        "node_modules/@types/ioredis-mock": {
+            "version": "8.2.5",
+            "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.5.tgz",
+            "integrity": "sha512-cZyuwC9LGtg7s5G9/w6rpy3IOZ6F/hFR0pQlWYZESMo1xQUYbDpa6haqB4grTePjsGzcB/YLBFCjqRunK5wieg==",
+            "dependencies": {
+                "@types/node": "*",
+                "ioredis": ">=5"
+            }
+        },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2957,24 +2972,6 @@
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true
-        },
-        "node_modules/@types/redis": {
-            "version": "2.8.32",
-            "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
-            "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/redis-mock": {
-            "version": "0.17.3",
-            "resolved": "https://registry.npmjs.org/@types/redis-mock/-/redis-mock-0.17.3.tgz",
-            "integrity": "sha512-1baXyGxRKEDog8p1ReiypODwiST2n3/0pBbgUKEuv9pBXnY6ttRzKATcW5Xz20ZOl9qkKtPIeq20tHgHSdQBAQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/redis": "^2.8.0"
-            }
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
@@ -4471,6 +4468,29 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
             "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
         },
+        "node_modules/fengari": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+            "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+            "dependencies": {
+                "readline-sync": "^1.4.9",
+                "sprintf-js": "^1.1.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "node_modules/fengari-interop": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.3.tgz",
+            "integrity": "sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==",
+            "peerDependencies": {
+                "fengari": "^0.1.0"
+            }
+        },
+        "node_modules/fengari/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+        },
         "node_modules/file-stream-rotator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
@@ -4996,6 +5016,55 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/ioredis"
             }
+        },
+        "node_modules/ioredis-mock": {
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.9.0.tgz",
+            "integrity": "sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==",
+            "dependencies": {
+                "@ioredis/as-callback": "^3.0.0",
+                "@ioredis/commands": "^1.2.0",
+                "fengari": "^0.1.4",
+                "fengari-interop": "^0.1.3",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12.22"
+            },
+            "peerDependencies": {
+                "@types/ioredis-mock": "^8",
+                "ioredis": "^5"
+            }
+        },
+        "node_modules/ioredis-mock/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ioredis-mock/node_modules/semver": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ioredis-mock/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/ioredis/node_modules/debug": {
             "version": "4.3.4",
@@ -6680,6 +6749,14 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7139,6 +7216,14 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/readline-sync": {
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+            "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/redis": {
@@ -7999,6 +8084,17 @@
             "dependencies": {
                 "es5-ext": "~0.10.46",
                 "next-tick": "1"
+            }
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
             }
         },
         "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.552.0",
         "@aws-sdk/client-ses": "^3.552.0",
+        "@types/ioredis-mock": "^8.2.5",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
         "class-transformer": "^0.5.1",
@@ -29,6 +30,7 @@
         "express-async-errors": "^3.1.1",
         "helmet": "^7.1.0",
         "ioredis": "^5.3.2",
+        "ioredis-mock": "^8.9.0",
         "jest": "^29.7.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
@@ -58,7 +60,6 @@
         "@types/multer-s3": "^3.0.3",
         "@types/node": "^20.11.19",
         "@types/nodemailer": "^6.4.14",
-        "@types/redis-mock": "^0.17.3",
         "@types/supertest": "^6.0.2",
         "@types/uuid4": "^2.0.3",
         "@types/validator": "^13.11.9",

--- a/src/common/utils/crypto.ts
+++ b/src/common/utils/crypto.ts
@@ -1,0 +1,5 @@
+import crypto from "crypto";
+
+export const createCode = () => {
+    return crypto.randomBytes(3).toString("hex");
+};

--- a/src/controllers/anonymous/anonymous.controller.ts
+++ b/src/controllers/anonymous/anonymous.controller.ts
@@ -178,7 +178,7 @@ export default class AnonymousController {
 
     // 사용자의 Email로 회원가입한 복수의 로그인 정보
     findMaskingUser = async (req: Request, res: Response) => {
-        const { email }: dto.EmailReqDTO = req.body;
+        const email = req.params.email;
 
         try {
             // domain 확인

--- a/src/controllers/anonymous/dto/anonymous.dto.ts
+++ b/src/controllers/anonymous/dto/anonymous.dto.ts
@@ -72,6 +72,12 @@ export class CheckEmailReqDTO {
     code!: string;
 }
 
+export class CheckUsernameReqDTO {
+    @IsString()
+    @IsNotEmpty()
+    username!: string;
+}
+
 export class ChangePasswordReqDTO {
     @IsString()
     @IsNotEmpty()

--- a/src/routes/anonymous.routes.ts
+++ b/src/routes/anonymous.routes.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Router } from "express";
+import { Router } from "express";
 
 import anonymousController from "@controllers/anonymous/anonymous.controller";
 import { validationMiddleware } from "@middlewares/requestValidate";
@@ -26,13 +26,13 @@ class AnonymousRoutes {
         this.router.post("/refresh", this.controller.refresh);
 
         // ID 찾기 API
-        this.router.post("/find-id", validationMiddleware(dto.EmailReqDTO), this.controller.findMaskingUser);
+        this.router.get("/find-id/:email", this.controller.findMaskingUser);
         this.router.post("/find-id/send-email", validationMiddleware(dto.SendIDReqDTO), this.controller.sendExactUserID);
 
         // PW 재변경 API
-        this.router.post("/change-password", validationMiddleware(dto.ChangePasswordReqDTO), this.controller.changePassword);
         this.router.post("/change-password/send-email", validationMiddleware(dto.EmailReqDTO), this.controller.sendEmailForPassword);
         this.router.post("/change-password/check-email", validationMiddleware(dto.CheckEmailReqDTO), this.controller.checkEmailForPassword);
+        this.router.post("/change-password", validationMiddleware(dto.ChangePasswordReqDTO), this.controller.changePassword);
     }
 }
 

--- a/src/routes/anonymous.routes.ts
+++ b/src/routes/anonymous.routes.ts
@@ -13,20 +13,23 @@ class AnonymousRoutes {
     }
 
     initializeRoutes() {
+        // 회원가입 API
         this.router.post("/signup", validationMiddleware(dto.SignupReqDTO), this.controller.signup);
         this.router.post("/signup/send-email", validationMiddleware(dto.EmailReqDTO), this.controller.sendEmailForSignup);
         this.router.post("/signup/check-email", validationMiddleware(dto.CheckEmailReqDTO), this.controller.checkEmailForSignup);
+        this.router.post("/signup/check-username", validationMiddleware(dto.CheckUsernameReqDTO), this.controller.checkUsername);
 
+        // 로그인  API
         this.router.post("/login", validationMiddleware(dto.LoginReqDTO), this.controller.login);
 
+        // Refresh token 발급 API
         this.router.post("/refresh", this.controller.refresh);
 
-        // Email로 회원가입한 정보 찾기 - ID 찾기 용
+        // ID 찾기 API
         this.router.post("/find-id", validationMiddleware(dto.EmailReqDTO), this.controller.findMaskingUser);
-        // Email, username으로 회원가입한 정확한 ID 정보를 Email 전송 - ID 찾기 용
         this.router.post("/find-id/send-email", validationMiddleware(dto.SendIDReqDTO), this.controller.sendExactUserID);
 
-        // Change password
+        // PW 재변경 API
         this.router.post("/change-password", validationMiddleware(dto.ChangePasswordReqDTO), this.controller.changePassword);
         this.router.post("/change-password/send-email", validationMiddleware(dto.EmailReqDTO), this.controller.sendEmailForPassword);
         this.router.post("/change-password/check-email", validationMiddleware(dto.CheckEmailReqDTO), this.controller.checkEmailForPassword);

--- a/src/routes/anonymous.routes.ts
+++ b/src/routes/anonymous.routes.ts
@@ -14,17 +14,17 @@ class AnonymousRoutes {
 
     initializeRoutes() {
         this.router.post("/signup", validationMiddleware(dto.SignupReqDTO), this.controller.signup);
-        this.router.post("/signup/send-email", validationMiddleware(dto.EmailReqDTO), this.controller.sendEmail);
-        this.router.post("/signup/check-email", validationMiddleware(dto.CheckEmailReqDTO), this.controller.checkEmail);
+        this.router.post("/signup/send-email", validationMiddleware(dto.EmailReqDTO), this.controller.sendEmailForSignup);
+        this.router.post("/signup/check-email", validationMiddleware(dto.CheckEmailReqDTO), this.controller.checkEmailForSignup);
 
         this.router.post("/login", validationMiddleware(dto.LoginReqDTO), this.controller.login);
 
         this.router.post("/refresh", this.controller.refresh);
 
-        // Email로 회원가입한 모든 정보 찾기 - ID 찾기 용
-        this.router.post("/find-id", validationMiddleware(dto.EmailReqDTO), this.controller.findUserAccountList);
+        // Email로 회원가입한 정보 찾기 - ID 찾기 용
+        this.router.post("/find-id", validationMiddleware(dto.EmailReqDTO), this.controller.findMaskingUser);
         // Email, username으로 회원가입한 정확한 ID 정보를 Email 전송 - ID 찾기 용
-        this.router.post("/find-id/send-email", validationMiddleware(dto.SendIDReqDTO), this.controller.sendUserLoginID);
+        this.router.post("/find-id/send-email", validationMiddleware(dto.SendIDReqDTO), this.controller.sendExactUserID);
 
         // Change password
         this.router.post("/change-password", validationMiddleware(dto.ChangePasswordReqDTO), this.controller.changePassword);

--- a/src/routes/anonymous.routes.ts
+++ b/src/routes/anonymous.routes.ts
@@ -14,10 +14,10 @@ class AnonymousRoutes {
 
     initializeRoutes() {
         // 회원가입 API
-        this.router.post("/signup", validationMiddleware(dto.SignupReqDTO), this.controller.signup);
         this.router.post("/signup/send-email", validationMiddleware(dto.EmailReqDTO), this.controller.sendEmailForSignup);
         this.router.post("/signup/check-email", validationMiddleware(dto.CheckEmailReqDTO), this.controller.checkEmailForSignup);
         this.router.post("/signup/check-username", validationMiddleware(dto.CheckUsernameReqDTO), this.controller.checkUsername);
+        this.router.post("/signup", validationMiddleware(dto.SignupReqDTO), this.controller.signup);
 
         // 로그인  API
         this.router.post("/login", validationMiddleware(dto.LoginReqDTO), this.controller.login);

--- a/src/services/anonymous/anonymous.service.ts
+++ b/src/services/anonymous/anonymous.service.ts
@@ -72,6 +72,10 @@ export default class AnonymousService {
         return user;
     };
 
+    findUserByUsername = async (username: string) => {
+        return await this.userRepo.getUserByUsername(username);
+    };
+
     changePassword = async (username: string, password: string) => {
         let user = await this.userRepo.getUserByUsername(username);
         if (!user) {

--- a/src/services/anonymous/anonymous.service.ts
+++ b/src/services/anonymous/anonymous.service.ts
@@ -5,7 +5,6 @@ import { convSignupToUser } from "./anonymous.conv";
 import { ErrAlreadyExist, ErrNotFound, ErrUnauthorized } from "@errors/handler";
 import { compareHashedValue, hashing } from "@utils/encryption";
 import { createUserResponse } from "@services/user/user.conv";
-import User from "@models/user";
 import { logger } from "@configs/logger";
 
 export default class AnonymousService {
@@ -50,8 +49,18 @@ export default class AnonymousService {
         return result;
     };
 
-    // user의 PK ID가 아닌 로그인 ID를 의미함
-    findLoginIDByUsername = async (email: string, username: string) => {
+    // find user by email
+    findUserByEmail = async (email: string) => {
+        const userList = await this.userRepo.getAllUsers();
+        for (const user of userList) {
+            if (await compareHashedValue(email, user.email)) {
+                return user;
+            }
+        }
+    };
+
+    // find user by email & username
+    findUserByEmailUsername = async (email: string, username: string) => {
         const user = await this.userRepo.getUserByUsername(username);
         if (!user) {
             logger.error("cant find user by username");
@@ -60,27 +69,7 @@ export default class AnonymousService {
         if (!(await compareHashedValue(email, user.email))) {
             throw ErrUnauthorized;
         }
-        return user.id;
-    };
-
-    findLoginID = async (email: string) => {
-        const userList = await this.userRepo.getAllUsers();
-        if (userList.length < 1) {
-            logger.error("cant find all user");
-            throw ErrNotFound;
-        }
-
-        let matchedUserList = [];
-        for (const user of userList) {
-            if (await compareHashedValue(email, user.email)) {
-                matchedUserList.push({
-                    email: email,
-                    username: user.username,
-                    id: maskLastThreeCharacters(user.id),
-                });
-            }
-        }
-        return matchedUserList;
+        return user;
     };
 
     changePassword = async (username: string, password: string) => {
@@ -96,15 +85,4 @@ export default class AnonymousService {
         // update user
         await this.userRepo.updateUser(user);
     };
-}
-
-function maskLastThreeCharacters(input: string): string {
-    if (input.length <= 3) {
-        return input.replace(/./g, "*"); // 문자열 전체를 '*'로 대체
-    }
-
-    const visiblePart = input.substring(0, input.length - 3); // 마지막 3개를 제외한 문자열
-    const maskedPart = input.substring(input.length - 3).replace(/./g, "*"); // 마지막 3개를 '*'로 대체
-
-    return visiblePart + maskedPart;
 }

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,0 +1,7 @@
+import request from "supertest";
+import app from "./setup";
+
+export const TestPOST = async (endpoint: string, body: any, statusCode: number) => {
+    let response: any = await request(app).post(endpoint).send(body);
+    expect(response.statusCode).toBe(statusCode);
+};

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,7 +1,22 @@
 import request from "supertest";
 import app from "./setup";
 
-export const TestPOST = async (endpoint: string, body: any, statusCode: number) => {
-    let response: any = await request(app).post(endpoint).send(body);
+export const TestGET = async (endpoint: string, statusCode: number, token?: string) => {
+    let response: any = await request(app).get(endpoint).set("Authorization", `Bearer ${token}`);
+    expect(response.statusCode).toBe(statusCode);
+};
+
+export const TestPOST = async (endpoint: string, body: any, statusCode: number, token?: string) => {
+    let response: any = await request(app).post(endpoint).send(body).set("Authorization", `Bearer ${token}`);
+    expect(response.statusCode).toBe(statusCode);
+};
+
+export const TestPUT = async (endpoint: string, body: any, statusCode: number, token?: string) => {
+    let response: any = await request(app).put(endpoint).send(body).set("Authorization", `Bearer ${token}`);
+    expect(response.statusCode).toBe(statusCode);
+};
+
+export const TestDELETE = async (endpoint: string, statusCode: number, token?: string) => {
+    let response: any = await request(app).delete(endpoint).set("Authorization", `Bearer ${token}`);
     expect(response.statusCode).toBe(statusCode);
 };

--- a/tests/services/user.test.ts
+++ b/tests/services/user.test.ts
@@ -1,28 +1,116 @@
 import request from "supertest";
-import app from "../setup";
+import app, { defaultID, defaultUsername, mockEmailCode } from "../setup";
+import { TestPOST } from "../common";
+import * as anonyDTO from "@controllers/anonymous/dto/anonymous.dto";
 
-interface userBody {
-    userId?: number;
-    id?: string;
-    password?: string;
-    username?: string;
-    email?: string;
-}
-
-// test용 user data
-let createdUser: userBody;
 let accessToken: string;
 let refreshToken: string;
 
+// test용 user data
+const id = "test1234";
+const password = "test5678";
+const username = "testuser";
+const email = "test1234@corelinesoft.com";
+
 describe("User API", () => {
-    describe("Signup API", () => {
-        let body: userBody;
+    interface userBody {
+        userId?: number;
+        id?: string;
+        password?: string;
+        username?: string;
+        email?: string;
+    }
+    let createdUser: userBody;
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // run test
+    describe("Signup API - send email", () => {
+        let body: anonyDTO.EmailReqDTO;
+        const endpoint = "/api/signup/send-email";
         beforeEach(() => {
             body = {
-                id: "test1234",
-                password: "test5678",
-                username: "testuser",
-                email: "test@a.com",
+                email: email,
+            };
+        });
+
+        describe("성공", () => {
+            test("Post - api/signup/send-email", async () => {
+                await TestPOST(endpoint, body, 200);
+            });
+        });
+        describe("Exception", () => {
+            test("invalid domain (email)", async () => {
+                body.email = "dsafa1231@naver.com";
+                await TestPOST(endpoint, body, 400);
+            });
+            test("already exist username", async () => {
+                body.email = defaultUsername;
+                await TestPOST(endpoint, body, 400);
+            });
+        });
+    });
+
+    describe("Signup API - check email", () => {
+        let body: anonyDTO.CheckEmailReqDTO;
+        const endpoint = "/api/signup/check-email";
+        beforeEach(() => {
+            body = {
+                email: email,
+                code: mockEmailCode,
+            };
+        });
+
+        describe("성공", () => {
+            test("Post - api/signup/check-email", async () => {
+                await TestPOST(endpoint, body, 200);
+            });
+        });
+        describe("Exception", () => {
+            test("invalid domain (email)", async () => {
+                body.email = "test123@naver.com";
+                await TestPOST(endpoint, body, 400);
+            });
+            test("invalid code", async () => {
+                body.code = "asa133";
+                await TestPOST(endpoint, body, 404);
+            });
+        });
+    });
+
+    describe("Signup API - check username", () => {
+        let body: anonyDTO.CheckUsernameReqDTO;
+        const endpoint = "/api/signup/check-username";
+        beforeEach(() => {
+            body = {
+                username: username,
+            };
+        });
+
+        describe("성공", () => {
+            test("Post - api/signup/check-email", async () => {
+                await TestPOST(endpoint, body, 200);
+            });
+        });
+        describe("Exception", () => {
+            test("alreay exist username", async () => {
+                body.username = defaultUsername;
+                await TestPOST(endpoint, body, 400);
+            });
+            test("invalid body", async () => {
+                body.username = "";
+                await TestPOST(endpoint, body, 400);
+            });
+        });
+    });
+
+    describe("Signup API", () => {
+        let body: anonyDTO.SignupReqDTO;
+        const endpoint = "/api/signup";
+        beforeEach(() => {
+            body = {
+                id: id,
+                password: password,
+                username: username,
+                email: email,
             };
         });
 
@@ -36,182 +124,181 @@ describe("User API", () => {
         describe("Exception", () => {
             test("empty id", async () => {
                 body.id = "";
-                let response: any = await request(app).post("/api/signup").send(body);
-                expect(response.statusCode).toBe(400);
+                await TestPOST(endpoint, body, 400);
             });
             test("empty password", async () => {
                 body.password = "";
-                let response: any = await request(app).post("/api/signup").send(body);
-                expect(response.statusCode).toBe(400);
+                await TestPOST(endpoint, body, 400);
             });
             test("empty username", async () => {
                 body.username = "";
-                let response: any = await request(app).post("/api/signup").send(body);
-                expect(response.statusCode).toBe(400);
+                await TestPOST(endpoint, body, 400);
             });
             test("empty & invalid email", async () => {
                 body.email = "";
-                let response: any = await request(app).post("/api/signup").send(body);
-                expect(response.statusCode).toBe(400);
+                await TestPOST(endpoint, body, 400);
 
                 body.email = "adga12113";
-                response = await request(app).post("/api/signup").send(body);
-                expect(response.statusCode).toBe(400);
+                await TestPOST(endpoint, body, 400);
+
+                // 이메일 인증이 안된 이메일
+                body.email = "dnflalk123@corelinesoft.com";
+                await TestPOST(endpoint, body, 401);
             });
         });
     });
 
-    describe("Login API", () => {
-        let body: any;
-        beforeEach(() => {
-            body = {
-                id: "test1234",
-                password: "test5678",
-            };
-        });
-        describe("성공", () => {
-            test("Post - /api/login", async () => {
-                const response: any = await request(app).post(`/api/login`).send(body);
-                expect(response.statusCode).toBe(200);
+    // describe("Login API", () => {
+    //     let body: any;
+    //     beforeEach(() => {
+    //         body = {
+    //             id: "test1234",
+    //             password: "test5678",
+    //         };
+    //     });
+    //     describe("성공", () => {
+    //         test("Post - /api/login", async () => {
+    //             const response: any = await request(app).post(`/api/login`).send(body);
+    //             expect(response.statusCode).toBe(200);
 
-                const result = response.body.data;
-                accessToken = result.accessToken;
-                refreshToken = result.refreshToken;
-                expect(result.accessToken).not.toBeNull();
-                expect(result.refreshToken).not.toBeNull();
-            });
-        });
-        describe("Exception", () => {
-            test("empty, invalid userID", async () => {
-                // empty case
-                body.id = "";
-                let response: any = await request(app).post(`/api/login`).send(body);
-                expect(response.statusCode).toBe(400);
+    //             const result = response.body.data;
+    //             accessToken = result.accessToken;
+    //             refreshToken = result.refreshToken;
+    //             expect(result.accessToken).not.toBeNull();
+    //             expect(result.refreshToken).not.toBeNull();
+    //         });
+    //     });
+    //     describe("Exception", () => {
+    //         test("empty, invalid userID", async () => {
+    //             // empty case
+    //             body.id = "";
+    //             let response: any = await request(app).post(`/api/login`).send(body);
+    //             expect(response.statusCode).toBe(400);
 
-                // invalid id case
-                body.id = "adnklal131";
-                response = await request(app).post(`/api/login`).send(body);
-                expect(response.statusCode).toBe(404);
-            });
-            test("empty, invalid password", async () => {
-                // empty case
-                body.password = "";
-                let response: any = await request(app).post(`/api/login`).send(body);
-                expect(response.statusCode).toBe(400);
+    //             // invalid id case
+    //             body.id = "adnklal131";
+    //             response = await request(app).post(`/api/login`).send(body);
+    //             expect(response.statusCode).toBe(404);
+    //         });
+    //         test("empty, invalid password", async () => {
+    //             // empty case
+    //             body.password = "";
+    //             let response: any = await request(app).post(`/api/login`).send(body);
+    //             expect(response.statusCode).toBe(400);
 
-                // invalid password case
-                body.password = "13nlflaqp1";
-                response = await request(app).post(`/api/login`).send(body);
-                expect(response.statusCode).toBe(404);
-            });
-        });
-    });
+    //             // invalid password case
+    //             body.password = "13nlflaqp1";
+    //             response = await request(app).post(`/api/login`).send(body);
+    //             expect(response.statusCode).toBe(404);
+    //         });
+    //     });
+    // });
 
-    describe("Get User API", () => {
-        describe("성공", () => {
-            test("Get - /api/users/{id}", async () => {
-                const response: any = await request(app)
-                    .get(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`);
-                expect(response.statusCode).toBe(200);
+    // describe("Get User API", () => {
+    //     describe("성공", () => {
+    //         test("Get - /api/users/{id}", async () => {
+    //             const response: any = await request(app)
+    //                 .get(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`);
+    //             expect(response.statusCode).toBe(200);
 
-                const result: userBody = response.body.data;
-                expect(result.id).toEqual(createdUser.id);
-                expect(result.password).toBeUndefined();
-                expect(result.username).toEqual(createdUser.username);
-                expect(result.email).toEqual(createdUser.email);
-            });
-        });
-        describe("Exception", () => {
-            test("not found user", async () => {
-                const response: any = await request(app)
-                    .get(`/api/users/${createdUser.userId! + 100}`)
-                    .set("Authorization", `Bearer ${accessToken}`);
-                expect(response.statusCode).toBe(404);
-            });
-        });
-    });
+    //             const result: userBody = response.body.data;
+    //             expect(result.id).toEqual(createdUser.id);
+    //             expect(result.password).toBeUndefined();
+    //             expect(result.username).toEqual(createdUser.username);
+    //             expect(result.email).toEqual(createdUser.email);
+    //         });
+    //     });
+    //     describe("Exception", () => {
+    //         test("not found user", async () => {
+    //             const response: any = await request(app)
+    //                 .get(`/api/users/${createdUser.userId! + 100}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`);
+    //             expect(response.statusCode).toBe(404);
+    //         });
+    //     });
+    // });
 
-    describe("Update User API", () => {
-        let body: userBody;
-        beforeEach(() => {
-            body = {
-                userId: 0, // not used this test
-                id: "", // not used this test
-                username: "",
-                password: "",
-                email: "",
-            };
-        });
-        describe("성공", () => {
-            test(`Put - /api/users/{id}) - username`, async () => {
-                body.username = "changeduser123";
-                delete body.email;
-                const response: any = await request(app)
-                    .put(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`)
-                    .send(body);
-                expect(response.statusCode).toBe(200);
+    // describe("Update User API", () => {
+    //     let body: userBody;
+    //     beforeEach(() => {
+    //         body = {
+    //             userId: 0, // not used this test
+    //             id: "", // not used this test
+    //             username: "",
+    //             password: "",
+    //             email: "",
+    //         };
+    //     });
+    //     describe("성공", () => {
+    //         test(`Put - /api/users/{id}) - username`, async () => {
+    //             body.username = "changeduser123";
+    //             delete body.email;
+    //             const response: any = await request(app)
+    //                 .put(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`)
+    //                 .send(body);
+    //             expect(response.statusCode).toBe(200);
 
-                const result: userBody = response.body.data;
-                expect(result.username).toEqual(body.username);
-            });
-            test(`Put - /api/users/{id}) - password`, async () => {
-                body.password = "changeduser313";
-                delete body.email;
-                const response: any = await request(app)
-                    .put(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`)
-                    .send(body);
-                expect(response.statusCode).toBe(200);
-            });
-            test(`Put - /api/users/{id}) - email`, async () => {
-                body.email = "changeduser@naver.com";
-                const response: any = await request(app)
-                    .put(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`)
-                    .send(body);
-                expect(response.statusCode).toBe(200);
+    //             const result: userBody = response.body.data;
+    //             expect(result.username).toEqual(body.username);
+    //         });
+    //         test(`Put - /api/users/{id}) - password`, async () => {
+    //             body.password = "changeduser313";
+    //             delete body.email;
+    //             const response: any = await request(app)
+    //                 .put(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`)
+    //                 .send(body);
+    //             expect(response.statusCode).toBe(200);
+    //         });
+    //         test(`Put - /api/users/{id}) - email`, async () => {
+    //             body.email = "changeduser@naver.com";
+    //             const response: any = await request(app)
+    //                 .put(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`)
+    //                 .send(body);
+    //             expect(response.statusCode).toBe(200);
 
-                const result: userBody = response.body.data;
-                expect(result.email).toEqual(body.email);
-            });
-        });
-        describe("Exception", () => {
-            test("invalid email", async () => {
-                body.email = "invalidemailformat";
-                const response: any = await request(app)
-                    .put(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`)
-                    .send(body);
-                expect(response.statusCode).toBe(400);
-            });
-            test("wrong authenticated", async () => {
-                body.email = "changeduser@naver.com";
-                const response: any = await request(app)
-                    .put(`/api/users/${createdUser.userId! + 100}`)
-                    .send(body);
-                expect(response.statusCode).toBe(401);
-            });
-        });
-    });
+    //             const result: userBody = response.body.data;
+    //             expect(result.email).toEqual(body.email);
+    //         });
+    //     });
+    //     describe("Exception", () => {
+    //         test("invalid email", async () => {
+    //             body.email = "invalidemailformat";
+    //             const response: any = await request(app)
+    //                 .put(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`)
+    //                 .send(body);
+    //             expect(response.statusCode).toBe(400);
+    //         });
+    //         test("wrong authenticated", async () => {
+    //             body.email = "changeduser@naver.com";
+    //             const response: any = await request(app)
+    //                 .put(`/api/users/${createdUser.userId! + 100}`)
+    //                 .send(body);
+    //             expect(response.statusCode).toBe(401);
+    //         });
+    //     });
+    // });
 
-    describe("Delete User API", () => {
-        describe("성공", () => {
-            test(`Delete - /api/users/{id})`, async () => {
-                const response: any = await request(app)
-                    .delete(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`);
-                expect(response.statusCode).toBe(200);
-            });
-        });
-        describe("Exception", () => {
-            test("not found user", async () => {
-                const response: any = await request(app)
-                    .delete(`/api/users/${createdUser.userId}`)
-                    .set("Authorization", `Bearer ${accessToken}`);
-                expect(response.statusCode).toBe(404);
-            });
-        });
-    });
+    // describe("Delete User API", () => {
+    //     describe("성공", () => {
+    //         test(`Delete - /api/users/{id})`, async () => {
+    //             const response: any = await request(app)
+    //                 .delete(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`);
+    //             expect(response.statusCode).toBe(200);
+    //         });
+    //     });
+    //     describe("Exception", () => {
+    //         test("not found user", async () => {
+    //             const response: any = await request(app)
+    //                 .delete(`/api/users/${createdUser.userId}`)
+    //                 .set("Authorization", `Bearer ${accessToken}`);
+    //             expect(response.statusCode).toBe(404);
+    //         });
+    //     });
+    // });
 });

--- a/tests/services/user.test.ts
+++ b/tests/services/user.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import app, { defaultID, defaultUsername, mockEmailCode } from "../setup";
-import { TestPOST } from "../common";
+import { TestDELETE, TestGET, TestPOST, TestPUT } from "../common";
 import * as anonyDTO from "@controllers/anonymous/dto/anonymous.dto";
 
 let accessToken: string;
@@ -22,7 +22,7 @@ describe("User API", () => {
     }
     let createdUser: userBody;
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // run test
+    // signup
     describe("Signup API - send email", () => {
         let body: anonyDTO.EmailReqDTO;
         const endpoint = "/api/signup/send-email";
@@ -50,8 +50,8 @@ describe("User API", () => {
     });
 
     describe("Signup API - check email", () => {
-        let body: anonyDTO.CheckEmailReqDTO;
         const endpoint = "/api/signup/check-email";
+        let body: anonyDTO.CheckEmailReqDTO;
         beforeEach(() => {
             body = {
                 email: email,
@@ -148,157 +148,224 @@ describe("User API", () => {
         });
     });
 
-    // describe("Login API", () => {
-    //     let body: any;
-    //     beforeEach(() => {
-    //         body = {
-    //             id: "test1234",
-    //             password: "test5678",
-    //         };
-    //     });
-    //     describe("성공", () => {
-    //         test("Post - /api/login", async () => {
-    //             const response: any = await request(app).post(`/api/login`).send(body);
-    //             expect(response.statusCode).toBe(200);
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // login
+    describe("Login API", () => {
+        let body: anonyDTO.LoginReqDTO;
+        const endpoint = "/api/login";
+        beforeEach(() => {
+            body = {
+                id: id,
+                password: password,
+            };
+        });
+        describe("성공", () => {
+            test("Post - /api/login", async () => {
+                const response: any = await request(app).post(endpoint).send(body);
+                expect(response.statusCode).toBe(200);
 
-    //             const result = response.body.data;
-    //             accessToken = result.accessToken;
-    //             refreshToken = result.refreshToken;
-    //             expect(result.accessToken).not.toBeNull();
-    //             expect(result.refreshToken).not.toBeNull();
-    //         });
-    //     });
-    //     describe("Exception", () => {
-    //         test("empty, invalid userID", async () => {
-    //             // empty case
-    //             body.id = "";
-    //             let response: any = await request(app).post(`/api/login`).send(body);
-    //             expect(response.statusCode).toBe(400);
+                const result = response.body.data;
+                accessToken = result.accessToken;
+                refreshToken = result.refreshToken;
+                expect(result.accessToken).not.toBeNull();
+                expect(result.refreshToken).not.toBeNull();
+            });
+        });
+        describe("Exception", () => {
+            test("empty, invalid userID", async () => {
+                // empty case
+                body.id = "";
+                await TestPOST(endpoint, body, 400);
 
-    //             // invalid id case
-    //             body.id = "adnklal131";
-    //             response = await request(app).post(`/api/login`).send(body);
-    //             expect(response.statusCode).toBe(404);
-    //         });
-    //         test("empty, invalid password", async () => {
-    //             // empty case
-    //             body.password = "";
-    //             let response: any = await request(app).post(`/api/login`).send(body);
-    //             expect(response.statusCode).toBe(400);
+                // invalid id case
+                body.id = "adnklal131";
+                await TestPOST(endpoint, body, 404);
+            });
+            test("empty, invalid password", async () => {
+                // empty case
+                body.password = "";
+                await TestPOST(endpoint, body, 400);
+                // invalid password case
+                body.password = "13nlflaqp1";
+                await TestPOST(endpoint, body, 404);
+            });
+        });
+    });
 
-    //             // invalid password case
-    //             body.password = "13nlflaqp1";
-    //             response = await request(app).post(`/api/login`).send(body);
-    //             expect(response.statusCode).toBe(404);
-    //         });
-    //     });
-    // });
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Find ID
+    describe("Find ID API", () => {
+        const endpoint = "/api/find-id";
 
-    // describe("Get User API", () => {
-    //     describe("성공", () => {
-    //         test("Get - /api/users/{id}", async () => {
-    //             const response: any = await request(app)
-    //                 .get(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`);
-    //             expect(response.statusCode).toBe(200);
+        describe("성공", () => {
+            test("Get - api/find-id/:email", async () => {
+                const response: any = await request(app).get(`${endpoint}/${email}`);
+                expect(response.statusCode).toBe(200);
+                expect(response.body.data.id).toEqual("test1***");
+                expect(response.body.data.username).toEqual("testuser");
+            });
+        });
+        describe("Exception", () => {
+            test("alreay exist username", async () => {
+                await TestGET(`${endpoint}/adsnk2@corelinesoft.com`, 404);
+            });
+        });
+    });
 
-    //             const result: userBody = response.body.data;
-    //             expect(result.id).toEqual(createdUser.id);
-    //             expect(result.password).toBeUndefined();
-    //             expect(result.username).toEqual(createdUser.username);
-    //             expect(result.email).toEqual(createdUser.email);
-    //         });
-    //     });
-    //     describe("Exception", () => {
-    //         test("not found user", async () => {
-    //             const response: any = await request(app)
-    //                 .get(`/api/users/${createdUser.userId! + 100}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`);
-    //             expect(response.statusCode).toBe(404);
-    //         });
-    //     });
-    // });
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Change Password
+    describe("Change Password API - send email", () => {
+        const endpoint = "/api/change-password/send-email";
+        let body: anonyDTO.EmailReqDTO;
+        beforeEach(() => {
+            body = {
+                email: email,
+            };
+        });
+        describe("성공", () => {
+            test("Get - api/find-id/:email", async () => {
+                await TestPOST(endpoint, body, 200);
+            });
+        });
+        describe("Exception", () => {
+            test("invalid domain (email)", async () => {
+                body.email = "dsafa1231@naver.com";
+                await TestPOST(endpoint, body, 400);
+            });
+            test("already exist username", async () => {
+                body.email = defaultUsername;
+                await TestPOST(endpoint, body, 400);
+            });
+        });
+    });
 
-    // describe("Update User API", () => {
-    //     let body: userBody;
-    //     beforeEach(() => {
-    //         body = {
-    //             userId: 0, // not used this test
-    //             id: "", // not used this test
-    //             username: "",
-    //             password: "",
-    //             email: "",
-    //         };
-    //     });
-    //     describe("성공", () => {
-    //         test(`Put - /api/users/{id}) - username`, async () => {
-    //             body.username = "changeduser123";
-    //             delete body.email;
-    //             const response: any = await request(app)
-    //                 .put(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`)
-    //                 .send(body);
-    //             expect(response.statusCode).toBe(200);
+    describe("Change Password API - check email", () => {
+        const endpoint = "/api/change-password/check-email";
+        let body: anonyDTO.CheckEmailReqDTO;
+        beforeEach(() => {
+            body = {
+                email: email,
+                code: mockEmailCode,
+            };
+        });
 
-    //             const result: userBody = response.body.data;
-    //             expect(result.username).toEqual(body.username);
-    //         });
-    //         test(`Put - /api/users/{id}) - password`, async () => {
-    //             body.password = "changeduser313";
-    //             delete body.email;
-    //             const response: any = await request(app)
-    //                 .put(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`)
-    //                 .send(body);
-    //             expect(response.statusCode).toBe(200);
-    //         });
-    //         test(`Put - /api/users/{id}) - email`, async () => {
-    //             body.email = "changeduser@naver.com";
-    //             const response: any = await request(app)
-    //                 .put(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`)
-    //                 .send(body);
-    //             expect(response.statusCode).toBe(200);
+        describe("성공", () => {
+            test("Post - api/signup/check-email", async () => {
+                await TestPOST(endpoint, body, 200);
+            });
+        });
+        describe("Exception", () => {
+            test("invalid domain (email)", async () => {
+                body.email = "test123@naver.com";
+                await TestPOST(endpoint, body, 400);
+            });
+            test("invalid code", async () => {
+                body.code = "asa133";
+                await TestPOST(endpoint, body, 404);
+            });
+        });
+    });
 
-    //             const result: userBody = response.body.data;
-    //             expect(result.email).toEqual(body.email);
-    //         });
-    //     });
-    //     describe("Exception", () => {
-    //         test("invalid email", async () => {
-    //             body.email = "invalidemailformat";
-    //             const response: any = await request(app)
-    //                 .put(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`)
-    //                 .send(body);
-    //             expect(response.statusCode).toBe(400);
-    //         });
-    //         test("wrong authenticated", async () => {
-    //             body.email = "changeduser@naver.com";
-    //             const response: any = await request(app)
-    //                 .put(`/api/users/${createdUser.userId! + 100}`)
-    //                 .send(body);
-    //             expect(response.statusCode).toBe(401);
-    //         });
-    //     });
-    // });
+    describe("Change Password API - change password", () => {
+        const endpoint = "/api/change-password";
+        let body: anonyDTO.ChangePasswordReqDTO;
+        beforeEach(() => {
+            body = {
+                email: email,
+                password: password + 123,
+                username: username,
+            };
+        });
 
-    // describe("Delete User API", () => {
-    //     describe("성공", () => {
-    //         test(`Delete - /api/users/{id})`, async () => {
-    //             const response: any = await request(app)
-    //                 .delete(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`);
-    //             expect(response.statusCode).toBe(200);
-    //         });
-    //     });
-    //     describe("Exception", () => {
-    //         test("not found user", async () => {
-    //             const response: any = await request(app)
-    //                 .delete(`/api/users/${createdUser.userId}`)
-    //                 .set("Authorization", `Bearer ${accessToken}`);
-    //             expect(response.statusCode).toBe(404);
-    //         });
-    //     });
-    // });
+        describe("성공", () => {
+            test("Post - api/signup/chnage-email", async () => {
+                await TestPOST(endpoint, body, 200);
+            });
+        });
+        describe("Exception", () => {
+            test("invalid domain (email)", async () => {
+                body.email = "test123@naver.com";
+                await TestPOST(endpoint, body, 400);
+            });
+            test("unauthorization email", async () => {
+                body.email = "test123@corelinesoft.com";
+                await TestPOST(endpoint, body, 401);
+            });
+        });
+    });
+
+    describe("Get User API", () => {
+        const endpoint = "/api/users";
+        describe("성공", () => {
+            test("Get - /api/users/{id}", async () => {
+                const response: any = await request(app)
+                    .get(`${endpoint}/${createdUser.userId}`)
+                    .set("Authorization", `Bearer ${accessToken}`);
+                expect(response.statusCode).toBe(200);
+
+                const result: userBody = response.body.data;
+                expect(result.id).toEqual(createdUser.id);
+                expect(result.password).toBeUndefined();
+                expect(result.username).toEqual(createdUser.username);
+                expect(result.email).toEqual(createdUser.email);
+            });
+        });
+        describe("Exception", () => {
+            test("not found user", async () => {
+                await TestGET(`${endpoint}/${createdUser.userId! + 100}`, 404, accessToken);
+            });
+        });
+    });
+
+    describe("Update User API", () => {
+        let body: userBody;
+        beforeEach(() => {
+            body = {
+                userId: 0, // not used this test
+                id: "", // not used this test
+                username: "",
+                password: "",
+                email: "",
+            };
+        });
+        describe("성공", () => {
+            test(`Put - /api/users/{id}) - username`, async () => {
+                body.username = "changeduser123";
+                delete body.email;
+                await TestPUT(`/api/users/${createdUser.userId}`, body, 200, accessToken);
+            });
+            test(`Put - /api/users/{id}) - password`, async () => {
+                body.password = "changeduser313";
+                delete body.email;
+                await TestPUT(`/api/users/${createdUser.userId}`, body, 200, accessToken);
+            });
+            test(`Put - /api/users/{id}) - email`, async () => {
+                body.email = "changeduser@naver.com";
+                await TestPUT(`/api/users/${createdUser.userId}`, body, 200, accessToken);
+            });
+        });
+        describe("Exception", () => {
+            test("invalid email", async () => {
+                body.email = "invalidemailformat";
+                await TestPUT(`/api/users/${createdUser.userId}`, body, 400, accessToken);
+            });
+            test("not found", async () => {
+                body.email = "changeduser@naver.com";
+                await TestPUT(`/api/users/${createdUser.userId! + 100}`, body, 404, accessToken);
+            });
+        });
+    });
+
+    describe("Delete User API", () => {
+        describe("성공", () => {
+            test(`Delete - /api/users/{id})`, async () => {
+                await TestDELETE(`/api/users/${createdUser.userId}`, 200, accessToken);
+            });
+        });
+        describe("Exception", () => {
+            test("not found user", async () => {
+                await TestDELETE(`/api/users/${createdUser.userId}`, 404, accessToken);
+            });
+        });
+    });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -44,6 +44,7 @@ const server = new Server(app);
 import Routes from "@src/routes";
 import UserRepo from "@repo/user.repo";
 import User from "@models/user";
+import { hashing } from "@utils/encryption";
 const route = new Routes(app);
 route.initialize();
 server.start(3000);
@@ -55,11 +56,13 @@ export const defaultUsername = "default123";
 beforeAll(async () => {
     const userRepo = new UserRepo();
     if (!(await userRepo.getUserByUsername(defaultUsername))) {
+        const pwd = await hashing(defaultPwd);
+        const mail = await hashing("defaultEmail123@corelinesoft.com");
         userRepo.createUser(
             new User({
                 id: defaultID,
-                password: defaultPwd,
-                email: "defaultEmail123@corelinesoft.com",
+                password: pwd,
+                email: mail,
                 username: defaultUsername,
                 activate: true,
             })

--- a/tests/utils/encryption.test.ts
+++ b/tests/utils/encryption.test.ts
@@ -1,4 +1,4 @@
-import { comparePassword, hashing } from "@utils/encryption";
+import { compareHashedValue, hashing } from "@utils/encryption";
 
 describe("encryption util", () => {
     let pwd = "test1234";
@@ -10,14 +10,14 @@ describe("encryption util", () => {
             expect(hashedPwd).not.toEqual(pwd);
         });
         test("compared", async () => {
-            const isEqual = await comparePassword(pwd, hashedPwd);
+            const isEqual = await compareHashedValue(pwd, hashedPwd);
             expect(isEqual).toEqual(true);
         });
     });
     describe("Exception", () => {
         test("not matched password", async () => {
             const wrongPwd = "wrongpassword";
-            const isEqual = await comparePassword(wrongPwd, hashedPwd);
+            const isEqual = await compareHashedValue(wrongPwd, hashedPwd);
             expect(isEqual).toEqual(false);
         });
     });


### PR DESCRIPTION
* username 중복 API 추가
* 이전 PR에서는 Email당 여러 계정 생성이 가능하게 로직을 짰으나 계정 당 1개로 정책 변경. 이에 맞춰 코드 변경
* anonymous route 부분 test 코드 전체적으로 반영
  * redis-mock을 사용하고 있었는데, ts는 ioredis 호환이 잘 맞아 ioredis-mock으로 변경하여 test 환경 구상