### PR TITLE
게시글, 댓글의 익명화된 Author 값이 저장될 수 있도록 로직 추가

### DIFF
--- a/src/common/utils/random.ts
+++ b/src/common/utils/random.ts
@@ -1,0 +1,78 @@
+export const generateRandomName = (): string => {
+    // 성격, 색깔, 동물 목록
+    const personalities = [
+        "용감한",
+        "소심한",
+        "친절한",
+        "날카로운",
+        "수줍은",
+        "활발한",
+        "차분한",
+        "낙천적인",
+        "냉정한",
+        "흥분한",
+        "자유로운",
+        "성숙한",
+        "유머러스한",
+        "귀여운",
+        "열정적인",
+        "진지한",
+        "유연한",
+        "극적인",
+        "탐험가",
+        "대담한",
+    ];
+    const colors = [
+        "빨간",
+        "파란",
+        "초록",
+        "노란",
+        "보라",
+        "주황",
+        "검정",
+        "분홍",
+        "회색",
+        "하늘색",
+        "갈색",
+        "금색",
+        "은색",
+        "하얀",
+        "자주색",
+        "연두색",
+        "갈대색",
+        "자색",
+        "올리브색",
+    ];
+    const animals = [
+        "사자",
+        "호랑이",
+        "코끼리",
+        "원숭이",
+        "팬더",
+        "곰",
+        "기린",
+        "캥거루",
+        "치타",
+        "오리",
+        "토끼",
+        "강아지",
+        "고양이",
+        "말",
+        "하마",
+        "코알라",
+        "코뿔소",
+        "쿼카",
+        "바다표범",
+        "앵무새",
+    ];
+
+    // 랜덤으로 성격, 색깔, 동물 선택
+    const randomPersonality = personalities[Math.floor(Math.random() * personalities.length)];
+    const randomColor = colors[Math.floor(Math.random() * colors.length)];
+    const randomAnimal = animals[Math.floor(Math.random() * animals.length)];
+
+    // 조합하여 이름 생성
+    const randomName = `${randomPersonality} ${randomColor} ${randomAnimal}`;
+
+    return randomName;
+};

--- a/src/controllers/comment/comment.controller.ts
+++ b/src/controllers/comment/comment.controller.ts
@@ -19,7 +19,7 @@ export default class CommentController {
             const body: dto.CreateCommentReqDTO = req.body;
 
             const result = await this.commentService.createComment(body, userId, postId);
-            sendJSONResponse(res, "success create comment", result.toJSON());
+            sendJSONResponse(res, "success create comment", result);
         } catch (err: any) {
             throw handleError(err);
         }

--- a/src/models/comment.ts
+++ b/src/models/comment.ts
@@ -6,6 +6,7 @@ import Post from "./post";
 class Comment extends Model<InferAttributes<Comment>, InferCreationAttributes<Comment>> {
     declare commentId: CreationOptional<number>;
     declare content: string;
+    declare author: string;
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
 
@@ -24,6 +25,10 @@ export const initComment = (sequelize: Sequelize) => {
                 primaryKey: true,
             },
             content: {
+                type: DataTypes.STRING,
+                allowNull: false,
+            },
+            author: {
                 type: DataTypes.STRING,
                 allowNull: false,
             },

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -8,6 +8,7 @@ class Post extends Model<InferAttributes<Post>, InferCreationAttributes<Post>> {
     declare postId: CreationOptional<number>;
     declare title: string;
     declare content: string;
+    declare author: string;
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
 
@@ -29,6 +30,10 @@ export const initPost = (sequelize: Sequelize) => {
                 allowNull: false,
             },
             content: {
+                type: DataTypes.STRING,
+                allowNull: false,
+            },
+            author: {
                 type: DataTypes.STRING,
                 allowNull: false,
             },

--- a/src/repository/comment.repo.ts
+++ b/src/repository/comment.repo.ts
@@ -1,16 +1,16 @@
 import Comment from "@models/comment";
-import { Op, Sequelize } from "sequelize";
+import { Op } from "sequelize";
 
 export default class CommentRepo {
-    constructor() { }
+    constructor() {}
 
-    createComment = async (comment: Comment) => {
-        return await Comment.create({
-            content: comment.content,
-            userId: comment.userId,
-            postId: comment.postId,
-            // 대댓글이 아니라면 null
-            parentId: comment.parentId,
+    getLastAnonymousCommentByPostId = async (postId: any) => {
+        return await Comment.findOne({
+            where: {
+                postId: postId,
+                author: { [Op.like]: "익명%" },
+            },
+            order: [["createdAt", "DESC"]], // createdAt 기준으로 내림차순으로 정렬하여 가장 최근 댓글을 가져옴
         });
     };
 
@@ -18,6 +18,14 @@ export default class CommentRepo {
         return await Comment.findOne({
             where: {
                 commentId: commentId,
+            },
+        });
+    };
+
+    getCommentByUserId = async (userId: any) => {
+        return await Comment.findOne({
+            where: {
+                userId: userId,
             },
         });
     };
@@ -31,7 +39,7 @@ export default class CommentRepo {
             include: {
                 model: Comment,
                 as: "replies",
-                required: false // 왼쪽 조인 사용
+                required: false, // 왼쪽 조인 사용
             },
         });
     };

--- a/src/repository/comment.repo.ts
+++ b/src/repository/comment.repo.ts
@@ -10,7 +10,7 @@ export default class CommentRepo {
                 postId: postId,
                 author: { [Op.like]: "익명%" },
             },
-            order: [["createdAt", "DESC"]], // createdAt 기준으로 내림차순으로 정렬하여 가장 최근 댓글을 가져옴
+            order: [["created_at", "DESC"]], // createdAt 기준으로 내림차순으로 정렬하여 가장 최근 댓글을 가져옴
         });
     };
 

--- a/src/services/comment/comment.conv.ts
+++ b/src/services/comment/comment.conv.ts
@@ -1,9 +1,10 @@
 import Comment from "@models/comment";
 import * as dto from "@controllers/comment/dto/comment.dto";
 
-export const convCreateDtoToComment = (commentDTO: dto.CreateCommentReqDTO, userId: any, postId: any) => {
+export const convCreateDtoToComment = (commentDTO: dto.CreateCommentReqDTO, userId: any, postId: any, author: string) => {
     return new Comment({
         content: commentDTO.content,
+        author : author,
         postId: postId,
         userId: userId,
         parentId: commentDTO.parentCommentId,

--- a/src/services/comment/comment.service.ts
+++ b/src/services/comment/comment.service.ts
@@ -47,19 +47,16 @@ export default class CommentService {
                     author = userComment.author;
                 } else {
                     // 3. `익명{next_number}`로 이름 배정
-                    const previousComment = await this.commentRepo.getLastAnonymousCommentByPostId(userId);
-                    if (previousComment) {
-                        const anonymousNumber = parseInt(previousComment.author.replace("익명", ""));
-                        author = `익명${anonymousNumber + 1}`;
-                    } else {
-                        author = "익명1";
-                    }
+                    const previousComment = await this.commentRepo.getLastAnonymousCommentByPostId(postId);
+                    const anonymousNumber = previousComment
+                        ? parseInt(previousComment.author.replace("익명", "")) + 1
+                        : 1; // 처음 댓글 시 1로 시작
+                    author = `익명${anonymousNumber}`;
                 }
             }
         }
 
         const newComment = convCreateDtoToComment(commentDTO, userId, postId, author);
-
         return await newComment.save();
     };
 

--- a/src/services/comment/comment.service.ts
+++ b/src/services/comment/comment.service.ts
@@ -18,12 +18,11 @@ export default class CommentService {
     }
 
     createComment = async (commentDTO: dto.CreateCommentReqDTO, userId: any, postId: any) => {
-        const newComment = convCreateDtoToComment(commentDTO, userId, postId);
-
+        const post = await this.postRepo.getPostByID(postId);
         // validation check
         {
             // 유효한 user, post인지 확인
-            if (!(await this.userRepo.getUserByPkID(userId)) || !(await this.postRepo.getPostByID(postId))) {
+            if (!(await this.userRepo.getUserByPkID(userId)) || !post) {
                 throw ErrInvalidArgument;
             }
 
@@ -35,7 +34,33 @@ export default class CommentService {
             }
         }
 
-        return await this.commentRepo.createComment(newComment);
+        // 댓글 author 설정
+        let author: string;
+        {
+            // 1. 작성자인지 확인
+            if (post.userId === userId) {
+                author = "작성자";
+            } else {
+                // 2. 이전에 작성했는지 확인
+                const userComment = await this.commentRepo.getCommentByUserId(userId);
+                if (userComment) {
+                    author = userComment.author;
+                } else {
+                    // 3. `익명{next_number}`로 이름 배정
+                    const previousComment = await this.commentRepo.getLastAnonymousCommentByPostId(userId);
+                    if (previousComment) {
+                        const anonymousNumber = parseInt(previousComment.author.replace("익명", ""));
+                        author = `익명${anonymousNumber + 1}`;
+                    } else {
+                        author = "익명1";
+                    }
+                }
+            }
+        }
+
+        const newComment = convCreateDtoToComment(commentDTO, userId, postId, author);
+
+        return await newComment.save();
     };
 
     getCommentWithReplies = async (postId: any) => {

--- a/src/services/post/post.conv.ts
+++ b/src/services/post/post.conv.ts
@@ -1,11 +1,13 @@
 import Post from "@models/post";
 import * as dto from "@controllers/post/dto/post.dto";
 import File from "@models/file";
+import { generateRandomName } from "@utils/random";
 
 export const convToPost = (createReq: dto.CreatePostReqDTO, boardId: number, userId: number): Post => {
     return new Post({
         title: createReq.title,
         content: createReq.content,
+        author :generateRandomName(),
         userId: userId,
         boardId: boardId,
     });


### PR DESCRIPTION
* 게시글의 author의 경우 `성격 +색깔 + 동물`로 랜덤 author 이름 생성
* 댓글의 경우 아래 case대로 생성됨
  - 작성자 댓글 - `작성자`
  - 그 외의 댓글은 추가 순서에 따라 `익명1`, `익명2`와 같이 익명 keyword에서 순서를 부여
    
![image](https://github.com/MunJunYeong/Ghost-Board-Backend/assets/75880594/967e6de3-4d69-4df9-9eaa-e0d2a0aebaab)
